### PR TITLE
Update README.md

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -13,7 +13,7 @@
 ### How to run services
 - Clone this repo from GitHub: `git clone https://github.com/dbeaver/team-edition-deploy`
 - `cd team-edition-deploy/k8s/cbte`
-- `cp ./example.values.yaml ./values.yaml`
+- `cp ./values.example.yaml ./values.yaml`
 - Edit chart values in `values.yaml` (use any text editor)
 - Configure domain and SSL certificate (optional)
   - Add an A record in your DNS hosting for a value of `cloudbeaverBaseDomain` variable with load balancer IP address.


### PR DESCRIPTION
correct name used in copy command for values.example.yaml

I tried to use the command as-is and it failed. This correction worked for me.