### PR TITLE
dbeaver/dbeaver-devops#2764 Update deployment upgrade instructions

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -234,7 +234,7 @@ For detailed instructions on how to use the script manager, refer to [manager do
 2. Stop the cluster: `docker-compose down` or `docker compose down`
 3. Update your deployment files:
    - Fetch latest changes: `git fetch`
-   - Switch to the matching release branch: `git checkout <version>` (e.g., `git checkout 25.2.0`)
+   - Switch to the branch for the version you're updating to: `git checkout <version>` (e.g., `git checkout 25.2.0`)
    - Change value of `CLOUDBEAVER_VERSION_TAG` in `.env` with a preferred version (skip if tag `latest` is set)
 4. Pull new docker images: `docker-compose pull` or `docker compose pull`
 5. Start the cluster: `docker-compose up -d` or `docker compose up -d`

--- a/compose/README.md
+++ b/compose/README.md
@@ -234,7 +234,7 @@ For detailed instructions on how to use the script manager, refer to [manager do
 2. Stop the cluster: `docker-compose down` or `docker compose down`
 3. Update your deployment files:
    - Fetch latest changes: `git fetch`
-   - Switch to new release version: `git checkout <version-tag>` (e.g., `git checkout 25.2.0`)
+   - Switch to the matching release branch: `git checkout <version>` (e.g., `git checkout 25.2.0`)
    - Change value of `CLOUDBEAVER_VERSION_TAG` in `.env` with a preferred version (skip if tag `latest` is set)
 4. Pull new docker images: `docker-compose pull` or `docker compose pull`
 5. Start the cluster: `docker-compose up -d` or `docker compose up -d`

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -57,7 +57,7 @@ Previously, the volumes were owned by the ‘root’ user, but now they are owne
 1. Change directory to `team-edition-deploy/k8s/cbte`.
 2. Update your deployment files:
    - Fetch the latest changes: `git fetch`.
-   - Switch to the matching release branch: `git checkout <version>` (for example, `git checkout 26.1.0`).
+   - Switch to the branch for the version you're updating to: `git checkout <version>` (for example, `git checkout 26.1.0`).
 3. Change the value of `imageTag` in the `values.yaml` configuration file to the preferred version. Skip this step if the tag is set to `latest`.
 4. Upgrade the cluster: `helm upgrade cloudbeaver-te ./ --values ./values.yaml`.
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -55,8 +55,11 @@ Previously, the volumes were owned by the ‘root’ user, but now they are owne
 #### Version update procedure
 
 1. Change directory to `team-edition-deploy/k8s/cbte`.
-2. Change value of `imageTag` in configuration file `values.yaml` with a preferred version. Go to next step if tag `latest` is set.
-3. Upgrade cluster: `helm upgrade cloudbeaver-te ./ --values ./values.yaml`
+2. Update your deployment files:
+   - Fetch the latest changes: `git fetch`.
+   - Switch to the matching release branch: `git checkout <version>` (for example, `git checkout 26.1.0`).
+3. Change the value of `imageTag` in the `values.yaml` configuration file to the preferred version. Skip this step if the tag is set to `latest`.
+4. Upgrade the cluster: `helm upgrade cloudbeaver-te ./ --values ./values.yaml`.
 
 ### Additional configuration
 


### PR DESCRIPTION
Closes dbeaver/dbeaver-devops#2764

- refresh Helm chart files by checking out the matching release branch before an upgrade
- correct the Compose procedure to identify version refs as release branches

Verification: `git diff --check`